### PR TITLE
added metadata.txt files copied verbatim from the `cdc-flusight-ensem…

### DIFF
--- a/inst/submissions/KoT-region/metadata.txt
+++ b/inst/submissions/KoT-region/metadata.txt
@@ -1,0 +1,10 @@
+team_name: ReichLab
+team_members: 'Evan L. Ray, Nicholas G. Reich'
+model_name: TBD
+model_abbr: TBD
+anonymity: named
+data_source1: TBD
+data_source2: TBD
+this_model_is_an_ensemble: FALSE
+methods: >-
+  TBD

--- a/inst/submissions/kcde-region/metadata.txt
+++ b/inst/submissions/kcde-region/metadata.txt
@@ -1,0 +1,20 @@
+team_name: ReichLab
+team_members: 'Evan L. Ray, Nicholas G. Reich'
+model_name: Kernel Conditional Density Estimation
+model_abbr: KCDE
+anonymity: named
+data_source1: ilinet
+data_source2: NULL
+this_model_is_an_ensemble: FALSE
+methods: >-
+  Used leave-one-season-out cross-validation in the training phase to estimate
+  1) parameters of kernel conditional density estimation (KCDE) models for
+  incidence h steps ahead, for h = 1, ..., 35; and 2) parameters of a copula C^H
+  modeling dependence structure across the next H weeks, for H = 2, ..., 35.
+  Together, these yield a joint predictive distribution for incidence in all
+  remaining weeks of the season.  Appropriate integrals of this joint
+  distribution are calculated via Monte Carlo integration to obtain predictions
+  for the seasonal quantities.  For making prospective predictions for each
+  season, only data before the start of that season were used in fitting model
+  parameters.  All code used in estimation and prediction is available at
+  https://github.com/reichlab/2017-2018-cdc-flu-contest

--- a/inst/submissions/kde-region/metadata.txt
+++ b/inst/submissions/kde-region/metadata.txt
@@ -1,0 +1,22 @@
+team_name: ReichLab
+team_members: 'Evan L. Ray, Nicholas G. Reich'
+model_name: Kernel Density Estimation
+model_abbr: KDE
+anonymity: named
+data_source1: ilinet
+data_source2: NULL
+this_model_is_an_ensemble: FALSE
+methods: >-
+  This model uses kernel density estimation to estimate a distribution for each
+  seasonal target and a generalized additive model (GAM) with a cyclical
+  seasonal spline to estimate the x-week ahead incidence targets. Both models
+  are based on observed values of that target in previous seasons within the
+  region of interest. We used Gaussian kernels and the default KDE settings from
+  the density function in the stats package for R to estimate the bandwidth
+  parameter for each KDE fit. For the peak incidence target, we fit to
+  log-transformed observations of historical peak incidence. For the onset week
+  prediction target, we estimated the probability of no onset as the proportion
+  of region-seasons in all regions in the training phase where no week in the
+  season met the criteria for being a season onset. We use the mccv R package to
+  fit the GAMs. All code used in estimation and prediction is available at
+  https://github.com/reichlab/2017-2018-cdc-flu-contest

--- a/inst/submissions/sarima_seasonal_difference_FALSE-region/metadata.txt
+++ b/inst/submissions/sarima_seasonal_difference_FALSE-region/metadata.txt
@@ -1,0 +1,21 @@
+team_name: ReichLab
+team_members: 'Evan L. Ray, Nicholas G. Reich'
+model_name: SARIMA model without seasonal differencing
+model_abbr: SARIMA1
+anonymity: named
+data_source1: ilinet
+data_source2: NULL
+this_model_is_an_ensemble: FALSE
+methods: >-
+  A seasonal ARIMA model is fit using the auto.arima function in the forecast
+  package for R.  The data are log-transformed and any infinite or missing
+  values after the transformation are linearly imputed before fitting the
+  model.  A separate model is fit for each region.  Through iterating the
+  one-step-ahead predictions, this model fit yields a joint predictive
+  distribution for incidence in all remaining weeks of the season.  Appropriate
+  integrals of this joint distribution are calculated via Monte Carlo
+  integration to obtain predictions for the seasonal quantities.  For making
+  prospective predictions for each season, only data before the start of that
+  season were used in fitting model parameters.  All code used in estimation and
+  prediction is available at
+  https://github.com/reichlab/2017-2018-cdc-flu-contest

--- a/inst/submissions/sarima_seasonal_difference_TRUE-region/metadata.txt
+++ b/inst/submissions/sarima_seasonal_difference_TRUE-region/metadata.txt
@@ -1,0 +1,21 @@
+team_name: ReichLab
+team_members: 'Evan L. Ray, Nicholas G. Reich'
+model_name: SARIMA model with seasonal differencing
+model_abbr: SARIMA2
+anonymity: named
+data_source1: ilinet
+data_source2: NULL
+this_model_is_an_ensemble: FALSE
+methods: >-
+  A seasonal ARIMA model is fit using the auto.arima function in the forecast
+  package for R.  The data are log-transformed, any infinite or missing values
+  after the transformation are linearly imputed, and a first-order seasonal
+  difference (at lag 52 weeks) is taken before fitting the model.  A separate
+  model is fit for each region.  Through iterating the one-step-ahead
+  predictions, this model fit yields a joint predictive distribution for
+  incidence in all remaining weeks of the season.  Appropriate integrals of this
+  joint distribution are calculated via Monte Carlo integration to obtain
+  predictions for the seasonal quantities.  For making prospective predictions
+  for each season, only data before the start of that season were used in
+  fitting model parameters.  All code used in estimation and prediction is
+  available at https://github.com/reichlab/2017-2018-cdc-flu-contest


### PR DESCRIPTION
added metadata.txt files copied verbatim from the `cdc-flusight-ensemble` repo, except for the KOT-region file, which has fields marked with 'TBD' that need filling in